### PR TITLE
Validation criteria translation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
-  - 2.2.1
-before_install: gem install bundler -v 1.11.2
+  - 2.3.8
+before_install: gem install bundler -v 1.17.3

--- a/lib/modiz/challenge_builder.rb
+++ b/lib/modiz/challenge_builder.rb
@@ -40,7 +40,9 @@ module Modiz
     end
 
     def criterias_index
-      @lines.find_index { |line| /\A### Crit/.match(line) }
+      criterias_index = @lines.find_index { |line| /\A### Crit/.match(line) }
+      criterias_index ||= @lines.find_index { |line| /\A### Validation (c|C)riteria/.match(line) }
+      criterias_index
     end
 
     def validations

--- a/lib/modiz/errors/error_message.rb
+++ b/lib/modiz/errors/error_message.rb
@@ -10,7 +10,7 @@ module Modiz
       NoQuestDescription: "Je ne reconnais pas le description de quêtes. Donnez un peu de contexte tout de même !",
       NoStepTitle: "Je n'ai pas réussi à trouver le titre de l'étape. Les titres d'étapes commencent par '### ' et se trouve après la section ##Etape, ligne :",
       NoChallengeTitle: "Je ne reconnais aucun titre pour le challenge.",
-      NoChallengeCriteriaMarkup: "Ta quête doit contenir le titre '### Critères de validation'.",
+      NoChallengeCriteriaMarkup: "Ta quête doit contenir le titre '### Critères de validation' ou '### Validation criteria'.",
       NoChallengeDescription: "Le challenge mérite d'être décrit, non ?",
       NoChallengeCriteria: "Ta quête doit contenir une liste de critères.",
       InvalidLink: "Les lien(s) suivant n'est(ne sont) pas valide(s) : "

--- a/lib/modiz/version.rb
+++ b/lib/modiz/version.rb
@@ -1,3 +1,3 @@
 module Modiz
-  VERSION = "0.2.15"
+  VERSION = "0.2.16"
 end

--- a/test/errors_test.rb
+++ b/test/errors_test.rb
@@ -11,7 +11,7 @@ module Modiz
     def test_invalid_challenge_delimiter
       quest_file = "\n\n## Etapes"
       err = assert_raises InvalidQuest::NoChallengeDelimiter do ; Parser.run(quest_file) ; end
-      assert_match /Je ne reconnais pas de ligne qui contient ## Challenge/, err.message
+      assert_match(/Je ne reconnais pas de ligne qui contient ## Challenge/, err.message)
     end
 
     def test_no_step_content
@@ -28,13 +28,13 @@ module Modiz
     def test_invalid_link
       quest_file = "\n\n## Etapes\nfoo\n \n## Challenge\n\n[url](wrong_link)"
       err = assert_raises InvalidQuest::InvalidLink do ; Parser.run(quest_file) ; end
-      assert_match /lien/, err.message
+      assert_match(/lien/, err.message)
     end
 
     def test_several_invalid_links
       quest_file = "\n\n## Etapes\nfoo\n\n## Challenge\n\n[url](wrong_link)[url](second_wrong_link)"
       err = assert_raises InvalidQuest::InvalidLink do ; Parser.run(quest_file) ; end
-      assert_match /wrong_link, second_wrong_link/, err.message
+      assert_match(/wrong_link, second_wrong_link/, err.message)
     end
 
     def test_no_step_title

--- a/test/modiz_test.rb
+++ b/test/modiz_test.rb
@@ -56,5 +56,5 @@ module Modiz
       assert_equal 4, quest_hash[:challenge_details][:criteria].count
       assert_nil quest_hash[:steps][3][:resources]
     end
- end
+  end
 end


### PR DESCRIPTION
Petit fix pour accepter la traduction anglaise de "Critères de validation" (j'ai fixé quelques warnings sur les tests au passage).

Sur Odyssey j'ai ajouté un test unitaire de quête en anglais (bon j'ai juste dupliqué l'existant pour l'upload réussi d'un markdown).

Le test passe (j'ai dû reporter mon fix de modiz dans le sous répertoire où bundler stocke les gems localement).

**Bizarrement** j'ai aussi dû update la config travis car mon build avait fail ! Alors que ton précédent commit utilisait la même config 🤔 

Je suppose qu'il faut en même temps mettre à jour la version de la Gem dans le Gemfile d'Odyssey, sinon les builds Travis doivent fail !?